### PR TITLE
feat: log Slack MCP Server connect URL on startup

### DIFF
--- a/claude-agent-sdk/app-oauth.js
+++ b/claude-agent-sdk/app-oauth.js
@@ -61,4 +61,8 @@ registerListeners(app);
   const port = Number.parseInt(process.env.PORT || '3000', 10);
   await app.start(port);
   app.logger.info(`Casey is running on port ${port}!`);
+  if (process.env.SLACK_REDIRECT_URI) {
+    const origin = new URL(process.env.SLACK_REDIRECT_URI).origin;
+    app.logger.info(`Connect the Slack MCP Server: ${origin}/slack/install`);
+  }
 })();

--- a/openai-agents-sdk/app-oauth.js
+++ b/openai-agents-sdk/app-oauth.js
@@ -61,4 +61,8 @@ registerListeners(app);
   const port = Number.parseInt(process.env.PORT || '3000', 10);
   await app.start(port);
   app.logger.info(`Casey is running on port ${port}!`);
+  if (process.env.SLACK_REDIRECT_URI) {
+    const origin = new URL(process.env.SLACK_REDIRECT_URI).origin;
+    app.logger.info(`Connect the Slack MCP Server: ${origin}/slack/install`);
+  }
 })();


### PR DESCRIPTION
### Summary

This pull request logs the Slack MCP Server install URL when the OAuth HTTP server starts. When `SLACK_REDIRECT_URI` is set, the app derives the origin and prints a `Connect the Slack MCP Server: <origin>/slack/install` message, making it easy for developers to find the OAuth install link.

### Testing

- Start the app with `node app-oauth.js` (or `slack run app-oauth.js`) with `SLACK_REDIRECT_URI` set
- Confirm the install URL is logged to the console after the "running on port" message
- Start the app without `SLACK_REDIRECT_URI` set and confirm no extra log line appears

```
[INFO]  bolt-app Casey is running on port 3000!
[INFO]  bolt-app Connect the Slack MCP Server: https://7e04-136-226-130-247.ngrok-free.app/slack/install
```