### PR TITLE
feat: show Slack MCP Server status on App Home in Socket Mode

### DIFF
--- a/claude-agent-sdk/listeners/views/app-home-builder.js
+++ b/claude-agent-sdk/listeners/views/app-home-builder.js
@@ -124,6 +124,25 @@ export function buildAppHomeView(installUrl = null, isConnected = false) {
         ],
       },
     );
+  } else {
+    blocks.push(
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: '\ud83d\udd34 *Slack MCP Server is disconnected.* <https://github.com/slack-samples/bolt-js-support-agent/blob/main/claude-agent-sdk/README.md#slack-mcp-server|Learn how to enable the Slack MCP Server.>',
+        },
+      },
+      {
+        type: 'context',
+        elements: [
+          {
+            type: 'mrkdwn',
+            text: 'The Slack MCP Server enables Casey to search messages, read channels, and more.',
+          },
+        ],
+      },
+    );
   }
 
   return { type: 'home', blocks };

--- a/claude-agent-sdk/tests/listeners/views/app-home-builder.test.js
+++ b/claude-agent-sdk/tests/listeners/views/app-home-builder.test.js
@@ -31,11 +31,13 @@ describe('buildAppHomeView', () => {
     }
   });
 
-  it('does not show MCP status by default', () => {
+  it('shows disconnected status with learn-more link by default', () => {
     const view = buildAppHomeView();
     const mrkdwnTexts = view.blocks.filter((b) => b.type === 'section').map((b) => b.text.text);
-    const hasMcp = mrkdwnTexts.some((t) => t.includes('MCP Server'));
-    assert.strictEqual(hasMcp, false);
+    const mcpText = mrkdwnTexts.find((t) => t.includes('MCP Server'));
+    assert.ok(mcpText);
+    assert.ok(mcpText.includes('disconnected'));
+    assert.ok(mcpText.includes('Learn how to enable'));
   });
 
   it('shows disconnected status when installUrl is provided', () => {

--- a/openai-agents-sdk/listeners/views/app-home-builder.js
+++ b/openai-agents-sdk/listeners/views/app-home-builder.js
@@ -124,6 +124,25 @@ export function buildAppHomeView(installUrl = null, isConnected = false) {
         ],
       },
     );
+  } else {
+    blocks.push(
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: '\ud83d\udd34 *Slack MCP Server is disconnected.* <https://github.com/slack-samples/bolt-js-support-agent/blob/main/openai-agents-sdk/README.md#slack-mcp-server|Learn how to enable the Slack MCP Server.>',
+        },
+      },
+      {
+        type: 'context',
+        elements: [
+          {
+            type: 'mrkdwn',
+            text: 'The Slack MCP Server enables Casey to search messages, read channels, and more.',
+          },
+        ],
+      },
+    );
   }
 
   return { type: 'home', blocks };

--- a/openai-agents-sdk/tests/listeners/views/app-home-builder.test.js
+++ b/openai-agents-sdk/tests/listeners/views/app-home-builder.test.js
@@ -31,11 +31,13 @@ describe('buildAppHomeView', () => {
     }
   });
 
-  it('does not show MCP status by default', () => {
+  it('shows disconnected status with learn-more link by default', () => {
     const view = buildAppHomeView();
     const mrkdwnTexts = view.blocks.filter((b) => b.type === 'section').map((b) => b.text.text);
-    const hasMcp = mrkdwnTexts.some((t) => t.includes('MCP Server'));
-    assert.strictEqual(hasMcp, false);
+    const mcpText = mrkdwnTexts.find((t) => t.includes('MCP Server'));
+    assert.ok(mcpText);
+    assert.ok(mcpText.includes('disconnected'));
+    assert.ok(mcpText.includes('Learn how to enable'));
   });
 
   it('shows disconnected status when installUrl is provided', () => {


### PR DESCRIPTION
### Summary

This pull request always shows the Slack MCP Server connection status on the App Home, including when the app is running in Socket Mode.

- Previously, the MCP status section was hidden when running in Socket Mode (no `SLACK_CLIENT_ID`). Now it displays as disconnected with a "Learn how to enable the Slack MCP Server" link pointing to the README.
- Updates tests to match the new default behavior.

### Preview

<img width="1035" height="354" alt="image" src="https://github.com/user-attachments/assets/42ac43c6-00de-45e4-9b83-c5ed8f01a4a3" />

### Testing

- Open the App Home while running in Socket Mode (`slack run` or `npm start`) and confirm the MCP status shows as disconnected with a learn-more link.
- Open the App Home while running in OAuth mode and confirm connected/disconnected status still works as before.
- Click the "Learn how to enable" link and confirm it navigates to the correct README section.