### PR TITLE
docs: rename IT Helpdesk Agent to IT Support Agent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-A monorepo containing two parallel implementations of **Casey**, an AI-powered IT helpdesk agent for Slack built with [Bolt for JavaScript](https://github.com/slackapi/bolt-js). Both implementations are functionally identical from the Slack user's perspective but use different AI agent frameworks.
+A monorepo containing two parallel implementations of **Casey**, an AI-powered IT support agent for Slack built with [Bolt for JavaScript](https://github.com/slackapi/bolt-js). Both implementations are functionally identical from the Slack user's perspective but use different AI agent frameworks.
 
 Casey can search a knowledge base, reset passwords, check system status, create tickets, and manage user permissions. When deployed with OAuth, Casey also connects to the [Slack MCP Server](https://docs.slack.dev/agents-ai/model-context-protocol) for searching messages, reading channels, sending messages, and managing canvases. All tool data is hardcoded for demo purposes.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Casey: IT Helpdesk Agent
+# Casey: IT Support Agent
 
-Meet Casey (it/this/that) — an AI-powered IT helpdesk agent that lives in Slack. Casey can troubleshoot common issues, search knowledge base articles, reset passwords, check system status, and create support tickets, all without leaving the conversation.
+Meet Casey (it/this/that) — an AI-powered IT support agent that lives in Slack. Casey can troubleshoot common issues, search knowledge base articles, reset passwords, check system status, and create support tickets, all without leaving the conversation.
 
 Built with [Bolt for JavaScript](https://tools.slack.dev/bolt-js/).
 

--- a/claude-agent-sdk/README.md
+++ b/claude-agent-sdk/README.md
@@ -1,6 +1,6 @@
-# Casey: IT Helpdesk Agent (Bolt for JavaScript and Claude Agent SDK)
+# Casey: IT Support Agent (Bolt for JavaScript and Claude Agent SDK)
 
-Meet Casey (it/this/that) — an AI-powered IT helpdesk agent that lives in Slack. Casey can troubleshoot common issues, search knowledge base articles, reset passwords, check system status, and create support tickets, all without leaving the conversation.
+Meet Casey (it/this/that) — an AI-powered IT support agent that lives in Slack. Casey can troubleshoot common issues, search knowledge base articles, reset passwords, check system status, and create support tickets, all without leaving the conversation.
 
 Built with [Bolt for JavaScript](https://tools.slack.dev/bolt-js/) and the [Claude Agent SDK](https://platform.claude.com/docs/en/agent-sdk/overview) using models from [Anthropic](https://www.anthropic.com).
 
@@ -304,7 +304,7 @@ The `casey.js` file configures the Claude Agent SDK agent with a system prompt, 
 
 Tools that need Slack API access (emoji reactions, mark resolved) are created as closures inside `runCaseyAgent()` that capture the dependencies. Static tools (knowledge base, tickets, etc.) remain as module-level exports in `agent/tools/`.
 
-The `tools` directory contains five IT helpdesk tools defined using `tool()` from the Claude Agent SDK with Zod v4 schemas.
+The `tools` directory contains five IT support tools defined using `tool()` from the Claude Agent SDK with Zod v4 schemas.
 
 ### `/thread-context`
 

--- a/claude-agent-sdk/listeners/views/app-home-builder.js
+++ b/claude-agent-sdk/listeners/views/app-home-builder.js
@@ -47,7 +47,7 @@ export function buildAppHomeView(installUrl = null, isConnected = false) {
       type: 'header',
       text: {
         type: 'plain_text',
-        text: "Hey there :wave: I'm Casey, your IT helpdesk agent.",
+        text: "Hey there :wave: I'm Casey, your IT support agent.",
       },
     },
     {

--- a/openai-agents-sdk/README.md
+++ b/openai-agents-sdk/README.md
@@ -1,6 +1,6 @@
-# Casey: IT Helpdesk Agent (Bolt for JavaScript and OpenAI Agents SDK)
+# Casey: IT Support Agent (Bolt for JavaScript and OpenAI Agents SDK)
 
-Meet Casey (it/this/that) — an AI-powered IT helpdesk agent that lives in Slack. Casey can troubleshoot common issues, search knowledge base articles, reset passwords, check system status, and create support tickets, all without leaving the conversation.
+Meet Casey (it/this/that) — an AI-powered IT support agent that lives in Slack. Casey can troubleshoot common issues, search knowledge base articles, reset passwords, check system status, and create support tickets, all without leaving the conversation.
 
 Built with [Bolt for JavaScript](https://tools.slack.dev/bolt-js/) and [OpenAI Agents SDK](https://openai.github.io/openai-agents-js/) using models from [OpenAI](https://openai.com).
 
@@ -304,7 +304,7 @@ The `support-agent.js` file defines the OpenAI Agents SDK Agent with a system pr
 
 The `deps.js` file defines the `CaseyDeps` class passed to the agent at runtime, providing access to the Slack client and conversation context.
 
-The `tools` directory contains five IT helpdesk tools defined using `tool()` from `@openai/agents`. Tools return plain strings.
+The `tools` directory contains five IT support tools defined using `tool()` from `@openai/agents`. Tools return plain strings.
 
 ### `/thread-context`
 

--- a/openai-agents-sdk/listeners/views/app-home-builder.js
+++ b/openai-agents-sdk/listeners/views/app-home-builder.js
@@ -47,7 +47,7 @@ export function buildAppHomeView(installUrl = null, isConnected = false) {
       type: 'header',
       text: {
         type: 'plain_text',
-        text: "Hey there :wave: I'm Casey, your IT helpdesk agent.",
+        text: "Hey there :wave: I'm Casey, your IT support agent.",
       },
     },
     {


### PR DESCRIPTION
### Summary

This pull request renames "IT Helpdesk Agent" to "IT Support Agent" across all READMEs, documentation, and the App Home greeting.

- Renames "IT Helpdesk" to "IT Support" in titles, descriptions, and project structure sections.
- Updates the App Home greeting from "your IT helpdesk agent" to "your IT support agent".

### Testing

- Run the app and confirm the App Home greeting says "IT support agent".
- Confirm READMEs render correctly on GitHub.