### PR TITLE
fix: replace hardcoded Casey name in App Home with dynamic bot name

### DIFF
--- a/claude-agent-sdk/listeners/events/app-home-opened.js
+++ b/claude-agent-sdk/listeners/events/app-home-opened.js
@@ -1,7 +1,7 @@
 import { buildAppHomeView } from '../views/app-home-builder.js';
 
 /**
- * Handle the app_home_opened event by publishing Casey's home view.
+ * Handle the app_home_opened event by publishing the app's home view.
  * @param {import('@slack/bolt').AllMiddlewareArgs & import('@slack/bolt').SlackEventMiddlewareArgs<'app_home_opened'>} args
  * @returns {Promise<void>}
  */
@@ -21,7 +21,7 @@ export async function handleAppHomeOpened({ client, context, logger }) {
       }
     }
 
-    const view = buildAppHomeView(installUrl, isConnected);
+    const view = buildAppHomeView(installUrl, isConnected, context.botUserId);
     await client.views.publish({ user_id: userId, view });
   } catch (e) {
     logger.error(`Failed to publish App Home: ${e}`);

--- a/claude-agent-sdk/listeners/views/app-home-builder.js
+++ b/claude-agent-sdk/listeners/views/app-home-builder.js
@@ -35,19 +35,20 @@ export const CATEGORIES = [
 ];
 
 /**
- * Build the App Home view for Casey.
+ * Build the App Home view.
  * @param {string | null} [installUrl] - OAuth install URL shown when MCP is disconnected.
  * @param {boolean} [isConnected] - Whether the Slack MCP Server is connected.
+ * @param {string | null} [botUserId] - The bot's user ID for dynamic mentions.
  * @returns {import('@slack/types').HomeView}
  */
-export function buildAppHomeView(installUrl = null, isConnected = false) {
+export function buildAppHomeView(installUrl = null, isConnected = false, botUserId = null) {
   /** @type {import('@slack/types').KnownBlock[]} */
   const blocks = [
     {
       type: 'header',
       text: {
         type: 'plain_text',
-        text: "Hey there :wave: I'm Casey, your IT helpdesk agent.",
+        text: "Hey there :wave: I'm your IT helpdesk agent.",
       },
     },
     {
@@ -79,7 +80,7 @@ export function buildAppHomeView(installUrl = null, isConnected = false) {
       elements: [
         {
           type: 'mrkdwn',
-          text: 'You can also mention me in any channel with `@Casey` or send me a DM.',
+          text: `You can also mention me in any channel${botUserId ? ` with <@${botUserId}>` : ''} or send me a DM.`,
         },
       ],
     },
@@ -100,7 +101,7 @@ export function buildAppHomeView(installUrl = null, isConnected = false) {
         elements: [
           {
             type: 'mrkdwn',
-            text: 'Casey has access to search messages, read channels, and more.',
+            text: 'This agent has access to search messages, read channels, and more.',
           },
         ],
       },
@@ -119,7 +120,7 @@ export function buildAppHomeView(installUrl = null, isConnected = false) {
         elements: [
           {
             type: 'mrkdwn',
-            text: 'The Slack MCP Server enables Casey to search messages, read channels, and more.',
+            text: 'The Slack MCP Server enables this agent to search messages, read channels, and more.',
           },
         ],
       },

--- a/claude-agent-sdk/listeners/views/app-home-builder.js
+++ b/claude-agent-sdk/listeners/views/app-home-builder.js
@@ -139,7 +139,7 @@ export function buildAppHomeView(installUrl = null, isConnected = false, botUser
         elements: [
           {
             type: 'mrkdwn',
-            text: 'The Slack MCP Server enables Casey to search messages, read channels, and more.',
+            text: 'The Slack MCP Server enables this agent to search messages, read channels, and more.',
           },
         ],
       },

--- a/claude-agent-sdk/tests/listeners/events/app-home-opened.test.js
+++ b/claude-agent-sdk/tests/listeners/events/app-home-opened.test.js
@@ -10,7 +10,7 @@ describe('handleAppHomeOpened', () => {
 
   beforeEach(() => {
     fakeClient = { views: { publish: mock.fn(async () => ({ ok: true })) } };
-    fakeContext = { userId: 'U123' };
+    fakeContext = { userId: 'U123', botUserId: 'U0BOT' };
     fakeLogger = { error: mock.fn() };
   });
 

--- a/claude-agent-sdk/tests/listeners/views/app-home-builder.test.js
+++ b/claude-agent-sdk/tests/listeners/views/app-home-builder.test.js
@@ -51,6 +51,20 @@ describe('buildAppHomeView', () => {
     const hasConnected = mrkdwnTexts.some((t) => t.includes('connected'));
     assert.strictEqual(hasConnected, true);
   });
+
+  it('includes bot mention in context when botUserId is provided', () => {
+    const view = buildAppHomeView(null, false, 'U0BOT');
+    const contextBlock = view.blocks.find((b) => b.type === 'context');
+    const mentionText = contextBlock.elements[0].text;
+    assert.ok(mentionText.includes('<@U0BOT>'));
+  });
+
+  it('omits bot mention when botUserId is not provided', () => {
+    const view = buildAppHomeView();
+    const contextBlock = view.blocks.find((b) => b.type === 'context');
+    const mentionText = contextBlock.elements[0].text;
+    assert.ok(!mentionText.includes('<@'));
+  });
 });
 
 describe('CATEGORIES', () => {

--- a/openai-agents-sdk/listeners/events/app-home-opened.js
+++ b/openai-agents-sdk/listeners/events/app-home-opened.js
@@ -1,7 +1,7 @@
 import { buildAppHomeView } from '../views/app-home-builder.js';
 
 /**
- * Handle the app_home_opened event by publishing Casey's home view.
+ * Handle the app_home_opened event by publishing the app's home view.
  * @param {import('@slack/bolt').AllMiddlewareArgs & import('@slack/bolt').SlackEventMiddlewareArgs<'app_home_opened'>} args
  * @returns {Promise<void>}
  */
@@ -21,7 +21,7 @@ export async function handleAppHomeOpened({ client, context, logger }) {
       }
     }
 
-    const view = buildAppHomeView(installUrl, isConnected);
+    const view = buildAppHomeView(installUrl, isConnected, context.botUserId);
     await client.views.publish({ user_id: userId, view });
   } catch (e) {
     logger.error(`Failed to publish App Home: ${e}`);

--- a/openai-agents-sdk/listeners/views/app-home-builder.js
+++ b/openai-agents-sdk/listeners/views/app-home-builder.js
@@ -35,19 +35,20 @@ export const CATEGORIES = [
 ];
 
 /**
- * Build the App Home view for Casey.
+ * Build the App Home view.
  * @param {string | null} [installUrl] - OAuth install URL shown when MCP is disconnected.
  * @param {boolean} [isConnected] - Whether the Slack MCP Server is connected.
+ * @param {string | null} [botUserId] - The bot's user ID for dynamic mentions.
  * @returns {import('@slack/types').HomeView}
  */
-export function buildAppHomeView(installUrl = null, isConnected = false) {
+export function buildAppHomeView(installUrl = null, isConnected = false, botUserId = null) {
   /** @type {import('@slack/types').KnownBlock[]} */
   const blocks = [
     {
       type: 'header',
       text: {
         type: 'plain_text',
-        text: "Hey there :wave: I'm Casey, your IT helpdesk agent.",
+        text: "Hey there :wave: I'm your IT helpdesk agent.",
       },
     },
     {
@@ -79,7 +80,7 @@ export function buildAppHomeView(installUrl = null, isConnected = false) {
       elements: [
         {
           type: 'mrkdwn',
-          text: 'You can also mention me in any channel with `@Casey` or send me a DM.',
+          text: `You can also mention me in any channel${botUserId ? ` with <@${botUserId}>` : ''} or send me a DM.`,
         },
       ],
     },
@@ -100,7 +101,7 @@ export function buildAppHomeView(installUrl = null, isConnected = false) {
         elements: [
           {
             type: 'mrkdwn',
-            text: 'Casey has access to search messages, read channels, and more.',
+            text: 'This agent has access to search messages, read channels, and more.',
           },
         ],
       },
@@ -119,7 +120,7 @@ export function buildAppHomeView(installUrl = null, isConnected = false) {
         elements: [
           {
             type: 'mrkdwn',
-            text: 'The Slack MCP Server enables Casey to search messages, read channels, and more.',
+            text: 'The Slack MCP Server enables this agent to search messages, read channels, and more.',
           },
         ],
       },

--- a/openai-agents-sdk/listeners/views/app-home-builder.js
+++ b/openai-agents-sdk/listeners/views/app-home-builder.js
@@ -139,7 +139,7 @@ export function buildAppHomeView(installUrl = null, isConnected = false, botUser
         elements: [
           {
             type: 'mrkdwn',
-            text: 'The Slack MCP Server enables Casey to search messages, read channels, and more.',
+            text: 'The Slack MCP Server enables this agent to search messages, read channels, and more.',
           },
         ],
       },

--- a/openai-agents-sdk/tests/listeners/events/app-home-opened.test.js
+++ b/openai-agents-sdk/tests/listeners/events/app-home-opened.test.js
@@ -10,7 +10,7 @@ describe('handleAppHomeOpened', () => {
 
   beforeEach(() => {
     fakeClient = { views: { publish: mock.fn(async () => ({ ok: true })) } };
-    fakeContext = { userId: 'U123' };
+    fakeContext = { userId: 'U123', botUserId: 'U0BOT' };
     fakeLogger = { error: mock.fn() };
   });
 

--- a/openai-agents-sdk/tests/listeners/views/app-home-builder.test.js
+++ b/openai-agents-sdk/tests/listeners/views/app-home-builder.test.js
@@ -51,6 +51,20 @@ describe('buildAppHomeView', () => {
     const hasConnected = mrkdwnTexts.some((t) => t.includes('connected'));
     assert.strictEqual(hasConnected, true);
   });
+
+  it('includes bot mention in context when botUserId is provided', () => {
+    const view = buildAppHomeView(null, false, 'U0BOT');
+    const contextBlock = view.blocks.find((b) => b.type === 'context');
+    const mentionText = contextBlock.elements[0].text;
+    assert.ok(mentionText.includes('<@U0BOT>'));
+  });
+
+  it('omits bot mention when botUserId is not provided', () => {
+    const view = buildAppHomeView();
+    const contextBlock = view.blocks.find((b) => b.type === 'context');
+    const mentionText = contextBlock.elements[0].text;
+    assert.ok(!mentionText.includes('<@'));
+  });
 });
 
 describe('CATEGORIES', () => {


### PR DESCRIPTION
### Summary

This pull request removes hardcoded "Casey" references in the App Home view and replaces them with generic text and a dynamic bot mention using `context.botUserId`. This allows the app name to be customized without the App Home being out of sync.

- Header changed from "I'm Casey, your IT helpdesk agent" to "I'm your IT helpdesk agent"
- Mention text uses `<@botUserId>` instead of backtick `@Casey`
- Static "Casey has access to…" strings replaced with "This agent has access to…"
- Added tests for the `botUserId` parameter

### Preview

<img width="1040" height="356" alt="image" src="https://github.com/user-attachments/assets/4bab9215-e5fa-4718-9810-7a1dcbc097a0" />


### Testing

- Run the app and open the App Home tab
- Verify the header no longer says "Casey"
- Verify the context block shows a dynamic `@mention` of the bot
- Verify the MCP status section uses generic "This agent" / "this agent" text
- Rename the app and confirm the App Home still renders correctly