### PR TITLE
fix: remove legacy search scope

### DIFF
--- a/claude-agent-sdk/manifest.json
+++ b/claude-agent-sdk/manifest.json
@@ -21,7 +21,6 @@
     "redirect_urls": ["https://ngrok-free.app/slack/oauth_redirect"],
     "scopes": {
       "user": [
-        "search:read",
         "channels:history",
         "channels:read",
         "groups:history",

--- a/openai-agents-sdk/manifest.json
+++ b/openai-agents-sdk/manifest.json
@@ -21,7 +21,6 @@
     "redirect_urls": ["https://ngrok-free.app/slack/oauth_redirect"],
     "scopes": {
       "user": [
-        "search:read",
         "channels:history",
         "channels:read",
         "groups:history",


### PR DESCRIPTION
### Type of change <!-- place an x in the [ ] that applies -->

- [ ] New feature
- [x] Bug fix
- [ ] Documentation

### Summary

[search:read](https://docs.slack.dev/reference/scopes/search.read/) is a legacy scope that should not be used in net new apps. The compatible API methods for this scope are not used in this project. The scope is not needed when using [Slack's MCP Server](https://docs.slack.dev/agents-ai/model-context-protocol).

### Requirements <!-- place an x in each [ ] that applies -->

- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
