### PR TITLE
docs: update Slack MCP Server URL in README.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 A monorepo containing two parallel implementations of **Casey**, an AI-powered IT support agent for Slack built with [Bolt for JavaScript](https://github.com/slackapi/bolt-js). Both implementations are functionally identical from the Slack user's perspective but use different AI agent frameworks.
 
-Casey can search a knowledge base, reset passwords, check system status, create tickets, and manage user permissions. When deployed with OAuth, Casey also connects to the [Slack MCP Server](https://docs.slack.dev/agents-ai/model-context-protocol) for searching messages, reading channels, sending messages, and managing canvases. All tool data is hardcoded for demo purposes.
+Casey can search a knowledge base, reset passwords, check system status, create tickets, and manage user permissions. When deployed with OAuth, Casey also connects to the [Slack MCP Server](https://docs.slack.dev/ai/slack-mcp-server) for searching messages, reading channels, sending messages, and managing canvases. All tool data is hardcoded for demo purposes.
 
 This repo uses a vendored (pre-release) build of `@slack/bolt` from the [bolt-js](https://github.com/slackapi/bolt-js) `main` branch. The `.tgz` file lives in `vendor/` and is referenced by each app's `package.json`.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Behind the scenes, Casey has access to five simulated tools: knowledge base sear
 
 ### Slack MCP Server
 
-Casey also works with the [Slack MCP Server](https://docs.slack.dev/agents-ai/model-context-protocol), giving it the ability to search messages and files, read channel history and threads, send messages, schedule messages, and create or update Slack canvases. When deployed with OAuth (HTTP mode), Casey automatically connects to the Slack MCP Server using the user's token, unlocking these capabilities on top of the built-in IT tools.
+Casey also works with the [Slack MCP Server](https://docs.slack.dev/ai/slack-mcp-server), giving it the ability to search messages and files, read channel history and threads, send messages, schedule messages, and create or update Slack canvases. When deployed with OAuth (HTTP mode), Casey automatically connects to the Slack MCP Server using the user's token, unlocking these capabilities on top of the built-in IT tools.
 
 ## Using the App
 

--- a/claude-agent-sdk/README.md
+++ b/claude-agent-sdk/README.md
@@ -25,7 +25,7 @@ Casey uses five simulated tools to assist users:
 
 ### Slack MCP Server
 
-Casey also works with the [Slack MCP Server](https://docs.slack.dev/agents-ai/model-context-protocol), giving it the ability to search messages and files, read channel history and threads, send messages, schedule messages, and create or update Slack canvases. When deployed with OAuth (HTTP mode), Casey automatically connects to the Slack MCP Server using the user's token, unlocking these capabilities on top of the built-in IT tools.
+Casey also works with the [Slack MCP Server](https://docs.slack.dev/ai/slack-mcp-server), giving it the ability to search messages and files, read channel history and threads, send messages, schedule messages, and create or update Slack canvases. When deployed with OAuth (HTTP mode), Casey automatically connects to the Slack MCP Server using the user's token, unlocking these capabilities on top of the built-in IT tools.
 
 ## Setup
 

--- a/openai-agents-sdk/README.md
+++ b/openai-agents-sdk/README.md
@@ -25,7 +25,7 @@ Casey uses five simulated tools to assist users:
 
 ### Slack MCP Server
 
-Casey also works with the [Slack MCP Server](https://docs.slack.dev/agents-ai/model-context-protocol), giving it the ability to search messages and files, read channel history and threads, send messages, schedule messages, and create or update Slack canvases. When deployed with OAuth (HTTP mode), Casey automatically connects to the Slack MCP Server using the user's token, unlocking these capabilities on top of the built-in IT tools.
+Casey also works with the [Slack MCP Server](https://docs.slack.dev/ai/slack-mcp-server), giving it the ability to search messages and files, read channel history and threads, send messages, schedule messages, and create or update Slack canvases. When deployed with OAuth (HTTP mode), Casey automatically connects to the Slack MCP Server using the user's token, unlocking these capabilities on top of the built-in IT tools.
 
 ## Setup
 


### PR DESCRIPTION
### Type of change <!-- place an x in the [ ] that applies -->

- [ ] New feature
- [ ] Bug fix
- [X] Documentation

### Summary

This pull request updates the Slack MCP Server URL to `https://docs.slack.dev/ai/slack-mcp-server` instead of `https://docs.slack.dev/agents-ai/model-context-protocol`, which now returns a soft-404 (renders the docs homepage; canonical URL points to `https://docs.slack.dev/`).

Mirrors the fix landed in [slack-samples/bolt-python-support-agent#97](https://github.com/slack-samples/bolt-python-support-agent/pull/97).

I review every other agent / assistant / MCP sample repo and this was the only remaining occurrence of the broken URL.

### Testing

- N/A

### Requirements <!-- place an x in each [ ] that applies -->

- [X] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)